### PR TITLE
Upload files with friendly file names 

### DIFF
--- a/src/Keboola/GoogleDriveWriter/Writer.php
+++ b/src/Keboola/GoogleDriveWriter/Writer.php
@@ -61,6 +61,19 @@ class Writer
         };
     }
 
+    private function tryParseNameFromManifest($filePath)
+    {
+        $name = basename($filePath);
+        $manifestFile = $filePath . '.manifest';
+        if (file_exists($manifestFile)) {
+            $manifest = json_decode(file_get_contents($manifestFile), true);
+            if (!empty($manifest['name'])) {
+                $name = $manifest['name'];
+            }
+        }
+        return $name;
+    }
+
     public function processFiles($filesConfig)
     {
         /** @var Finder $finder */
@@ -71,7 +84,7 @@ class Writer
             $file = $filesConfig;
             /** @var SplFileInfo $fileInfo */
             $file['inputFile'] = $fileInfo->getFilename();
-            $file['title'] = $file['inputFile'];
+            $file['title'] = $this->tryParseNameFromManifest($fileInfo->getRealPath());
             $gdFiles = $this->client->listFiles(sprintf("trashed=false and name='%s'", $file['inputFile']));
 
             if (!empty($gdFiles['files'])) {

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -307,7 +307,7 @@ class FunctionalTest extends BaseTest
         $process = $this->runProcess($config);
         $this->assertEquals(0, $process->getExitCode(), $process->getOutput());
 
-        $gdFiles = $this->client->listFiles("name contains 'wr-google-drive-64.png' and trashed != true");
+        $gdFiles = $this->client->listFiles("name contains 'titanic-named-file.png' and trashed != true");
         $this->assertArrayHasKey('files', $gdFiles);
         $this->assertNotEmpty($gdFiles['files']);
         $this->assertCount(1, $gdFiles['files']);

--- a/tests/data/in/files/wr-google-drive-64.png.manifest
+++ b/tests/data/in/files/wr-google-drive-64.png.manifest
@@ -4,7 +4,7 @@
     "is_public": false,
     "is_sliced": false,
     "is_encrypted": true,
-    "name": "wr-google-drive.png",
+    "name": "titanic-named-file.png",
     "size_bytes": 563416,
     "tags": [
         "wr-google-drive",


### PR DESCRIPTION
pri uploade suborov z `in/files` sa ako `title` dokumentu pouzije `name` z jeho manifestu.