### PR TITLE
Convert error 4xx to UserException + test

### DIFF
--- a/src/Keboola/GoogleDriveWriter/Application.php
+++ b/src/Keboola/GoogleDriveWriter/Application.php
@@ -83,7 +83,7 @@ class Application
             if ($e->getCode() == 403) {
                 $this->container['writer']->handleError403($e);
             }
-            if ($e->getCode() == 400) {
+            if ($e->getCode() >= 400 && $e->getCode() < 500) {
                 throw new UserException($e->getMessage());
             }
             if ($e->getCode() >= 500 && $e->getCode() < 600) {


### PR DESCRIPTION
Solving: https://keboola.atlassian.net/browse/COM-249

Changes:
- Client errors `4xx` are converted to `UserException`, tested on duplicate file error - `409`.